### PR TITLE
Tarefas não estavam sendo canceladas

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -33,7 +33,7 @@ class Todo(db.Model):
     name = db.Column(db.String(80), nullable=False)
     description = db.Column(db.String(300), nullable=False)
     urgent = db.Column(db.Boolean(), nullable=False)
-    state = db.Column(db.String(5), nullable=False)
+    state = db.Column(db.String(15), nullable=False)
 
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     user = db.relationship(

--- a/app/static/scripts/todo.py
+++ b/app/static/scripts/todo.py
@@ -137,7 +137,7 @@ def change_state(task_id, new_state):
     json = {'state': new_state}
 
     req = ajax.Ajax()
-    req.open('PATCH', f'/tasks/{task_id}', True)
+    req.open('PATCH', f'/tasks/{task_id}/', True)
     req.set_header('content-type', 'application/json')
     req.send(JSON.stringify(json))
     return req

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -48,7 +48,10 @@ def run_migrations_offline():
     """
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
-        url=url, target_metadata=target_metadata, literal_binds=True
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True
     )
 
     with context.begin_transaction():
@@ -84,7 +87,8 @@ def run_migrations_online():
             connection=connection,
             target_metadata=target_metadata,
             process_revision_directives=process_revision_directives,
-            **current_app.extensions['migrate'].configure_args
+            **current_app.extensions['migrate'].configure_args,
+            compare_type=True
         )
 
         with context.begin_transaction():

--- a/migrations/versions/b383438641b9_.py
+++ b/migrations/versions/b383438641b9_.py
@@ -1,0 +1,33 @@
+"""Alterando tamanho do campo STATE
+
+Revision ID: b383438641b9
+Revises: 82b0f7c525e6
+Create Date: 2020-09-23 09:51:04.054342
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b383438641b9'
+down_revision = '82b0f7c525e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('todo', schema=None) as batch_op:
+        batch_op.alter_column('state',
+                   existing_type=sa.VARCHAR(length=5),
+                   type_=sa.String(length=15),
+                   existing_nullable=False)
+
+
+
+def downgrade():
+    with op.batch_alter_table('todo', schema=None) as batch_op:
+        batch_op.alter_column( 'state',
+                   existing_type=sa.String(length=15),
+                   type_=sa.VARCHAR(length=5),
+                   existing_nullable=False)


### PR DESCRIPTION
Depois de rodar em produção, essa parte do codigo:

```python
if new_state in states:
        task.state = new_state
        current_app.db.session.commit()
```
Retornou o seguinte erro:

```
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(5)
```

Ele estava tendo problema em dar o update no banco de dados, pra "canceled" que tem 8 caracteres, já que o limite definido é 5 caracteres.

```python
state = db.Column(db.String(5), nullable=False)
```
E depois de aumentar pra 15, funcionou.
```python
state = db.Column(db.String(15), nullable=False)
```