### PR TITLE
Contador de caracteres e mensagem de erro ao ultrapassar limite dos campos

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -46,3 +46,16 @@
     background: var(--error-color);
     border-color: var(--error-color);
 }
+
+/* Style of todo description character counter |
+ Estilo do contador de caracteres da descrição */
+#desc-counter {
+    float: right;
+}
+
+/* Style of todo name character counter |
+ Estilo do contador de caracteres do nome */
+#name-counter{
+  float: right;
+  padding-top: 0.1em;
+}

--- a/app/static/scripts/todo.py
+++ b/app/static/scripts/todo.py
@@ -158,9 +158,20 @@ def task_register(evt):
     name = document.select_one('[name="name"]')
     desc = document.select_one('[name="desc"]')
     urgent = document.select_one('[name="urgent"]')
+    counter_name = document.select_one('#name-current')
+    counter_desc = document.select_one('#desc-current')
+
 
     if not name.value:
         error_message('Você esqueceu de preencher o campo "Nome"')
+        return
+
+    elif len(name.value) > 80:
+        error_message('Ei, o campo "Nome" da sua tarefa está muito grande, o limite é 80 caracteres')
+        return
+
+    elif len(desc.value) > 300:
+        error_message('Ei, o campo "Descrição" da sua tarefa está muito grande, o limite é 300 caracteres')
         return
 
     json = {
@@ -173,6 +184,8 @@ def task_register(evt):
     name.value = ''
     desc.value = ''
     urgent.checked = False
+    counter_name.text = 0
+    counter_desc.text = 0
 
     request('/tasks', json=json, bind=register_task)
 
@@ -212,6 +225,20 @@ def get_todos(req):
 def check_error_message(evt):
     if (error := document.select_one('#error')) :
         error.remove()
+
+@bind('[name="name"]', 'input')
+def description_char_counter(evt):
+    document.select_one('#name-current').text = str(
+    len(document.select_one('[name="name"]').value))
+
+    check_error_message(evt)
+
+@bind('[name="desc"]', 'input')
+def description_char_counter(evt):
+    document.select_one('#desc-current').text = str(
+    len(document.select_one('[name="desc"]').value))
+
+    check_error_message(evt)
 
 
 ajax.get('/tasks', oncomplete=get_todos)

--- a/app/static/scripts/todo.py
+++ b/app/static/scripts/todo.py
@@ -184,8 +184,8 @@ def task_register(evt):
     name.value = ''
     desc.value = ''
     urgent.checked = False
-    counter_name.text = 0
-    counter_desc.text = 0
+    counter_name.text = "0"
+    counter_desc.text = "0"
 
     request('/tasks', json=json, bind=register_task)
 

--- a/app/templates/comp_create.html
+++ b/app/templates/comp_create.html
@@ -8,10 +8,18 @@
       <div class="form-group">
         <label for="name">Nome da tarefa:</label>
         <input type="text" name="name" value="" autocomplete="off" /required>
+        <div id="name-counter">
+          <span id = "name-current">0 </span>
+          <span>/ 80 </span>
+        </div>
       </div>
       <div class="form-group">
         <label for="desc">Descrição da tarefa:</label>
         <textarea name="desc" rows="8" cols="20" autocomplete="off" /required></textarea>
+        <div id="desc-counter">
+          <span id = "desc-current">0 </span>
+          <span>/ 300 </span>
+        </div>
       </div>
       <div class="form-group">
         <label for="urgent">Tarefa urgente:</label>

--- a/features/criacao_de_tarefas.feature
+++ b/features/criacao_de_tarefas.feature
@@ -54,3 +54,17 @@ Funcionalidade: Criação de tarefas
       | nome       | descrição               | urgente |
       | Fazer bolo | não esquecer o fermento | False   |
     Então a tarefa no topo da pilha "A fazer" não deverá ter indicativo de urgência
+
+  Cenário: Não deve ser possível criar uma tarefa com mais de 80 caracteres no campo nome
+    Quando criar tarefa com 81 ou mais caracteres no campo nome
+    Então a mensagem de aviso deverá ser exibida
+      """
+      Ei, o campo "Nome" da sua tarefa está muito grande, o limite é 80 caracteres
+      """
+
+  Cenário: Não deve ser possível criar uma tarefa com mais de 300 caracteres na descrição
+    Quando criar tarefa com 301 ou mais caracteres no campo descrição
+    Então a mensagem de aviso deverá ser exibida
+      """
+      Ei, o campo "Descrição" da sua tarefa está muito grande, o limite é 300 caracteres
+      """


### PR DESCRIPTION
*Tentei fazer uma coisinha aqui, espero q seja util*

O banco de dados limita o tamanho do nome e descrição da tarefa, ou seja, quando a descrição tinha mais que 300 caracteres estava retornando 500, então eu fiz um contador de caracteres e uma mensagem de erro, impedindo a criação da tarefa.


Quando o nome da tarefa ultrapassa os 80 caracteres:
![Erro no nome](https://user-images.githubusercontent.com/56316646/94199864-d8d77a00-fe8f-11ea-85ae-caa1a3ce5a8f.png)
Descrição da imagem: A imagem representa o formulario para criação da tarefa, onde é exibido uma mensagem de erro avisando que o campo nome tem mais que 80 caracteres

Quando a descrição da tarefa ultrapassa os 300 caracteres:
![Erro na descrição](https://user-images.githubusercontent.com/56316646/94199861-d7a64d00-fe8f-11ea-8111-4209e1e6c69c.png)
Descrição da imagem: A imagem representa o formulario para criação da tarefa, onde é exibido uma mensagem de erro avisando que o campo descrição tem mais que 300 caracteres

