### PR TITLE
Criação da classe WaitablePageObject

### DIFF
--- a/features/page_objects/pages.py
+++ b/features/page_objects/pages.py
@@ -71,10 +71,6 @@ class CreateTodo(PageObject):
             lambda driver: driver.find_element_by_css_selector('#wait')
         )
 
-    def wait_error_message(self):
-        WebDriverWait(self.w, 20).until(
-            lambda driver: 'terminal-alert-error' in driver.page_source
-        )
 
 
 class TaskColumn(PageObject):
@@ -111,11 +107,6 @@ class Login(PageObject):
             EC.element_to_be_clickable((By.NAME, name))
         )
 
-    def wait_error_message(self):
-        WebDriverWait(self.w, 20).until(
-            lambda driver: 'terminal-alert-error' in driver.page_source
-        )
-
 
 class CreateUser(PageObject):
     name = PageElement(name='nome')
@@ -130,8 +121,3 @@ class CreateUser(PageObject):
         self.email = email
         self.password = senha
         self.submit.click()
-
-    def wait_error_message(self):
-        WebDriverWait(self.w, 20).until(
-            lambda driver: 'terminal-alert-error' in driver.page_source
-        )

--- a/features/page_objects/pages.py
+++ b/features/page_objects/pages.py
@@ -47,7 +47,7 @@ class Task:
         self.driver.find_element_by_css_selector('.btn-ghost.cancel').click()
 
 
-class CreateTodo(PageObject):
+class CreateTodo(WaitablePageObject):
     name = PageElement(name='name')
     description = PageElement(name='desc')
     urgent = PageElement(name='urgent')
@@ -70,7 +70,6 @@ class CreateTodo(PageObject):
         WebDriverWait(self.w, 20).until_not(
             lambda driver: driver.find_element_by_css_selector('#wait')
         )
-
 
 
 class TaskColumn(PageObject):
@@ -96,7 +95,7 @@ class Done(TaskColumn):
     selector = '.terminal-timeline.done .terminal-card'
 
 
-class Login(PageObject):
+class Login(WaitablePageObject):
     email = PageElement(name='email')
     password = PageElement(name='senha')
     submit = PageElement(css='input[value="Login"]')
@@ -108,7 +107,7 @@ class Login(PageObject):
         )
 
 
-class CreateUser(PageObject):
+class CreateUser(WaitablePageObject):
     name = PageElement(name='nome')
     email = PageElement(name='email')
     email_label = PageElement(css='.form-group:nth-child(2) > label')

--- a/features/page_objects/pages.py
+++ b/features/page_objects/pages.py
@@ -18,6 +18,16 @@ def wait_task(driver, css):
     )
 
 
+class WaitablePageObject(PageObject):
+
+    """Aguarda pela mensagem de erro"""
+
+    def wait_error_message(self):
+        WebDriverWait(self.w, 20).until(
+            lambda driver: 'terminal-alert-error' in driver.page_source
+        )
+
+
 class Task:
     def __init__(self, driver):
         self.driver = driver


### PR DESCRIPTION
Seguindo os passos da issue #33, eu fiz a implementação da classe `WaitablePageObject` a fim de eliminar a repetição do método `wait_error_message` nas _Page Objetcs_.

A implementação da classe ficou da seguinte forma:
```py
class WaitablePageObject(PageObject):

    """Aguarda pela mensagem de erro"""

    def wait_error_message(self):
        WebDriverWait(self.w, 20).until(
            lambda driver: 'terminal-alert-error' in driver.page_source
        )
```
Após a criação da classe acima, eu fiz a remoção do método `wait_error_message` nas seguintes classes:

- `CreateTodo`
- `Login`
- `CreateUser`

Além disso, mudei a herança das classes citadas de `PageObject` para a nova classe `WaitablePageObject`.

Após essas modificações no código, executei o `black` no arquivo modificado e em seguida executei os testes com o `behave`:
```sh
black -S -l 79 features/page_objects/pages.py
behave
```
Todos os testes passaram, como antes das alterações :blush: 
 